### PR TITLE
Ensure _DEBUG is defined when needed

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,3 +14,4 @@ build_script:
   - cd examples\HelloWorld\build
   - cmake ..
   - cmake --build .
+  - cmake --build . --config Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ script:
   - cd examples/HelloWorld/build
   - cmake ..
   - cmake --build .
+  - cmake .. -DCMAKE_BUILD_TYPE=Release
+  - cmake --build .

--- a/cmake/CMakejucer.cmake
+++ b/cmake/CMakejucer.cmake
@@ -121,6 +121,10 @@ function(jucer_project_end)
 
   if(APPLE)
     target_compile_options(${JUCER_PROJECT_NAME} PRIVATE -std=c++11)
+
+    if(NOT DEFINED CMAKE_BUILD_TYPE)
+      set(CMAKE_BUILD_TYPE "Debug")
+    endif()
     target_compile_definitions(${JUCER_PROJECT_NAME} PRIVATE $<$<CONFIG:Debug>:_DEBUG>)
 
     list(REMOVE_DUPLICATES JUCER_PROJECT_OSX_FRAMEWORKS)

--- a/cmake/CMakejucer.cmake
+++ b/cmake/CMakejucer.cmake
@@ -121,9 +121,7 @@ function(jucer_project_end)
 
   if(APPLE)
     target_compile_options(${JUCER_PROJECT_NAME} PRIVATE -std=c++11)
-    target_compile_definitions(${JUCER_PROJECT_NAME} PRIVATE
-      $<$<CONFIG:Debug>:_DEBUG>
-    )
+    target_compile_definitions(${JUCER_PROJECT_NAME} PRIVATE $<$<CONFIG:Debug>:_DEBUG>)
 
     list(REMOVE_DUPLICATES JUCER_PROJECT_OSX_FRAMEWORKS)
     foreach(framework_name ${JUCER_PROJECT_OSX_FRAMEWORKS})


### PR DESCRIPTION
Fix the warnings on Travis CI due to `_DEBUG` not being defined. Also build in Release configuration on CI.

@MartyLake: please have a look, thanks!