### PR TITLE
Support JUCE_* config flags

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,9 +9,13 @@ install:
 
   - git clone -q https://github.com/julianstorer/JUCE.git ../JUCE --depth=1
 
+  - mkdir C:\SDKs
+  - ps: Invoke-WebRequest -Uri http://www.steinberg.net/sdk_downloads/vstsdk366_27_06_2016_build_61.zip -OutFile C:\SDKs\vstsdk3.zip
+  - 7z x C:\SDKs\vstsdk3.zip -oC:\SDKs
+
 build_script:
-  - mkdir examples\AudioAppExample\build
-  - cd examples\AudioAppExample\build
+  - mkdir "examples\audio plugin host\build"
+  - cd "examples\audio plugin host\build"
   - cmake ..
   - cmake --build . --config Debug
   - cmake --build . --config Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,13 @@ install:
 
   - git clone -q https://github.com/julianstorer/JUCE.git ../JUCE --depth=1
 
+  - mkdir ~/SDKs
+  - curl http://www.steinberg.net/sdk_downloads/vstsdk366_27_06_2016_build_61.zip -o ~/SDKs/vstsdk3.zip
+  - unzip -q ~/SDKs/vstsdk3.zip -d ~/SDKs
+
 script:
-  - mkdir examples/AudioAppExample/build
-  - cd examples/AudioAppExample/build
+  - mkdir "examples/audio plugin host/build"
+  - cd "examples/audio plugin host/build"
   - cmake .. -DCMAKE_BUILD_TYPE=Debug
   - cmake --build .
   - cmake .. -DCMAKE_BUILD_TYPE=Release

--- a/cmake/AppConfig.h
+++ b/cmake/AppConfig.h
@@ -12,4 +12,5 @@
 
 #define JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED 1
 
+@config_flags_defines@
 #endif  // __JUCE_APPCONFIG__

--- a/cmake/CMakejucer.cmake
+++ b/cmake/CMakejucer.cmake
@@ -46,9 +46,9 @@ function(jucer_project_module module_name PATH_TAG module_path)
   list(APPEND JUCER_PROJECT_INCLUDE_DIRS "${module_path}")
   set(JUCER_PROJECT_INCLUDE_DIRS ${JUCER_PROJECT_INCLUDE_DIRS} PARENT_SCOPE)
 
-  get_filename_component(obj_cpp_module_file
+  get_filename_component(objcxx_module_file
     "${module_path}/${module_name}/${module_name}.mm" ABSOLUTE)
-  if(APPLE AND EXISTS "${obj_cpp_module_file}")
+  if(APPLE AND EXISTS "${objcxx_module_file}")
     set(extension "mm")
   else()
     set(extension "cpp")

--- a/cmake/CMakejucer.cmake
+++ b/cmake/CMakejucer.cmake
@@ -108,6 +108,12 @@ function(jucer_project_end)
       endif()
       string(CONCAT config_flags_defines "${config_flags_defines}" "#endif\n\n")
 
+      if(${flag_name} STREQUAL "JUCE_PLUGINHOST_AU")
+        if(flag_value)
+          list(APPEND JUCER_PROJECT_OSX_FRAMEWORKS "AudioUnit" "CoreAudioKit")
+        endif()
+      endif()
+
       unset(flag_name)
     endif()
   endforeach()

--- a/cmake/CMakejucer.cmake
+++ b/cmake/CMakejucer.cmake
@@ -59,6 +59,9 @@ function(jucer_project_module module_name PATH_TAG module_path)
     "${CMAKE_CURRENT_BINARY_DIR}/JuceLibraryCode/${module_name}.${extension}")
   set(JUCER_PROJECT_SOURCES ${JUCER_PROJECT_SOURCES} PARENT_SCOPE)
 
+  list(APPEND JUCER_CONFIG_FLAGS ${ARGN})
+  set(JUCER_CONFIG_FLAGS ${JUCER_CONFIG_FLAGS} PARENT_SCOPE)
+
   set(module_header_file "${module_path}/${module_name}/${module_name}.h")
 
   file(STRINGS "${module_header_file}" osx_frameworks_line REGEX "OSXFrameworks:")
@@ -87,6 +90,26 @@ function(jucer_project_end)
       "${module_available_defines}"
       "#define JUCE_MODULE_AVAILABLE_${module_name} 1\n"
     )
+  endforeach()
+  foreach(element ${JUCER_CONFIG_FLAGS})
+    if(NOT DEFINED flag_name)
+      set(flag_name ${element})
+    else()
+      set(flag_value ${element})
+
+      string(CONCAT config_flags_defines
+        "${config_flags_defines}" "#ifndef    ${flag_name}\n")
+      if(flag_value)
+        string(CONCAT config_flags_defines
+          "${config_flags_defines}" " #define   ${flag_name} 1\n")
+      else()
+        string(CONCAT config_flags_defines
+          "${config_flags_defines}" " #define   ${flag_name} 0\n")
+      endif()
+      string(CONCAT config_flags_defines "${config_flags_defines}" "#endif\n\n")
+
+      unset(flag_name)
+    endif()
   endforeach()
   configure_file("${JUCE.cmake_ROOT}/cmake/AppConfig.h" "JuceLibraryCode/AppConfig.h")
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,6 +24,7 @@ project("examples")
 
 add_subdirectory("AnimationAppExample")
 add_subdirectory("AudioAppExample")
+add_subdirectory("audio plugin host")
 add_subdirectory("BouncingBallWavetableDemo")
 add_subdirectory("ComponentTutorialExample")
 add_subdirectory("HelloWorld")

--- a/examples/audio plugin host/CMakeLists.txt
+++ b/examples/audio plugin host/CMakeLists.txt
@@ -1,0 +1,155 @@
+# Copyright (c) 2016 Alain Martin
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.0)
+
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../..")
+include(JUCE)
+
+
+set(Plugin_Host_jucer_FILE
+  "${JUCE_DIR}/examples/audio plugin host/Plugin Host.jucer"
+  CACHE PATH "Path to Plugin Host.jucer")
+
+get_filename_component(Plugin_Host_jucer_DIR
+  "${Plugin_Host_jucer_FILE}" DIRECTORY)
+
+file(COPY "${Plugin_Host_jucer_DIR}/Source" DESTINATION "${CMAKE_CURRENT_LIST_DIR}")
+
+
+if(WIN32)
+  set(VST3_SDK_Folder_fallback "C:/SDKs/VST3 SDK")
+else()
+  set(VST3_SDK_Folder_fallback "~/SDKs/VST3 SDK")
+endif()
+set(VST3_SDK_Folder "${VST3_SDK_Folder_fallback}" CACHE PATH "VST3 SDK Folder")
+
+
+jucer_project_begin("Plugin Host")
+
+jucer_project_files("Plugin Host/Source"
+  "Source/FilterGraph.cpp"
+  "Source/FilterGraph.h"
+  "Source/GraphEditorPanel.cpp"
+  "Source/GraphEditorPanel.h"
+  "Source/HostStartup.cpp"
+  "Source/InternalFilters.cpp"
+  "Source/InternalFilters.h"
+  "Source/MainHostWindow.cpp"
+  "Source/MainHostWindow.h"
+)
+
+jucer_project_module(
+  juce_audio_basics
+  PATH "${Plugin_Host_jucer_DIR}/../../modules"
+)
+
+jucer_project_module(
+  juce_audio_devices
+  PATH "${Plugin_Host_jucer_DIR}/../../modules"
+  # JUCE_ASIO
+  JUCE_WASAPI ON
+  # JUCE_WASAPI_EXCLUSIVE
+  JUCE_DIRECTSOUND ON
+  JUCE_ALSA ON
+  # JUCE_JACK
+  # JUCE_USE_ANDROID_OPENSLES
+  JUCE_USE_CDREADER OFF
+  JUCE_USE_CDBURNER OFF
+)
+
+jucer_project_module(
+  juce_audio_formats
+  PATH "${Plugin_Host_jucer_DIR}/../../modules"
+  JUCE_USE_FLAC OFF
+  JUCE_USE_OGGVORBIS OFF
+  # JUCE_USE_MP3AUDIOFORMAT
+  # JUCE_USE_LAME_AUDIO_FORMAT
+  # JUCE_USE_WINDOWS_MEDIA_FORMAT
+)
+
+jucer_project_module(
+  juce_audio_processors
+  PATH "${Plugin_Host_jucer_DIR}/../../modules"
+  JUCE_PLUGINHOST_VST ON
+  JUCE_PLUGINHOST_VST3 ON
+  JUCE_PLUGINHOST_AU ON
+)
+
+jucer_project_module(
+  juce_audio_utils
+  PATH "${Plugin_Host_jucer_DIR}/../../modules"
+)
+
+jucer_project_module(
+  juce_core
+  PATH "${Plugin_Host_jucer_DIR}/../../modules"
+)
+
+jucer_project_module(
+  juce_cryptography
+  PATH "${Plugin_Host_jucer_DIR}/../../modules"
+)
+
+jucer_project_module(
+  juce_data_structures
+  PATH "${Plugin_Host_jucer_DIR}/../../modules"
+)
+
+jucer_project_module(
+  juce_events
+  PATH "${Plugin_Host_jucer_DIR}/../../modules"
+)
+
+jucer_project_module(
+  juce_graphics
+  PATH "${Plugin_Host_jucer_DIR}/../../modules"
+)
+
+jucer_project_module(
+  juce_gui_basics
+  PATH "${Plugin_Host_jucer_DIR}/../../modules"
+)
+
+jucer_project_module(
+  juce_gui_extra
+  PATH "${Plugin_Host_jucer_DIR}/../../modules"
+  JUCE_WEB_BROWSER OFF
+  # JUCE_ENABLE_LIVE_CONSTANT_EDITOR
+)
+
+jucer_project_module(
+  juce_opengl
+  PATH "${Plugin_Host_jucer_DIR}/../../modules"
+)
+
+jucer_project_module(
+  juce_video
+  PATH "${Plugin_Host_jucer_DIR}/../../modules"
+  # JUCE_DIRECTSHOW
+  # JUCE_MEDIAFOUNDATION
+  JUCE_QUICKTIME OFF
+  JUCE_USE_CAMERA OFF
+)
+
+jucer_project_end()
+
+target_include_directories(Plugin_Host PRIVATE "${VST3_SDK_Folder}")


### PR DESCRIPTION
This PR adds support for `JUCE_*` config flags, which are then used in the `Plugin Host` example.

@MartyLake: please review, thanks!