### PR TITLE
Fix parsing .projucer files with only one exporter

### DIFF
--- a/Jucer2CMake/main.cpp
+++ b/Jucer2CMake/main.cpp
@@ -345,7 +345,7 @@ int main(int argc, char* argv[])
     }
 
     const auto modulePaths = jucerProject.getChildWithName("EXPORTFORMATS")
-                               .getChild(1)
+                               .getChild(0)
                                .getChildWithName("MODULEPATHS");
 
     for (const auto& moduleName : moduleNames)


### PR DESCRIPTION
Use the contents of the first exporter when parsing the modulepath.