### PR TITLE
Warn when jucer_export_target() isn't called with the relevant exporter

### DIFF
--- a/Jucer2CMake/CMakeLists.txt
+++ b/Jucer2CMake/CMakeLists.txt
@@ -64,4 +64,16 @@ jucer_project_module(
   PATH "${JUCE_ROOT}/modules"
 )
 
+jucer_export_target(
+  "Xcode (MacOSX)"
+)
+
+jucer_export_target(
+  "Visual Studio 2015"
+)
+
+jucer_export_target(
+  "Visual Studio 2013"
+)
+
 jucer_project_end()

--- a/cmake/BinaryDataBuilder/CMakeLists.txt
+++ b/cmake/BinaryDataBuilder/CMakeLists.txt
@@ -114,6 +114,18 @@ jucer_project_module(
   PATH "${Projucer_jucer_DIR}/../../modules"
 )
 
+jucer_export_target(
+  "Xcode (MacOSX)"
+)
+
+jucer_export_target(
+  "Visual Studio 2015"
+)
+
+jucer_export_target(
+  "Visual Studio 2013"
+)
+
 jucer_project_end()
 
 

--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -19,7 +19,7 @@ cmake_minimum_required(VERSION 3.4)
 
 
 set(Reprojucer.cmake_DIR "${CMAKE_CURRENT_LIST_DIR}")
-set(templates_DIR "${Reprojucer.cmake_DIR}/templates")
+set(Reprojucer_templates_DIR "${Reprojucer.cmake_DIR}/templates")
 
 
 function(jucer_project_begin)
@@ -281,7 +281,7 @@ function(jucer_project_module module_name PATH_TAG modules_folder)
 
     if(to_compile)
       get_filename_component(src_file_basename "${src_file}" NAME)
-      configure_file("${templates_DIR}/JuceLibraryCode-Wrapper.cpp"
+      configure_file("${Reprojucer_templates_DIR}/JuceLibraryCode-Wrapper.cpp"
         "JuceLibraryCode/${src_file_basename}"
       )
       list(APPEND JUCER_PROJECT_SOURCES
@@ -474,7 +474,9 @@ function(jucer_project_end)
 
   if(WIN32)
     string(REPLACE "." "," comma_separated_version_number "${JUCER_PROJECT_VERSION}")
-    configure_file("${templates_DIR}/resources.rc" "JuceLibraryCode/resources.rc")
+    configure_file("${Reprojucer_templates_DIR}/resources.rc"
+      "JuceLibraryCode/resources.rc"
+    )
     list(APPEND JUCER_PROJECT_SOURCES
       "${CMAKE_CURRENT_BINARY_DIR}/JuceLibraryCode/resources.rc"
     )
@@ -832,7 +834,7 @@ function(__generate_AppConfig_header project_id)
     endforeach()
   endif()
 
-  configure_file("${templates_DIR}/AppConfig.h" "JuceLibraryCode/AppConfig.h")
+  configure_file("${Reprojucer_templates_DIR}/AppConfig.h" "JuceLibraryCode/AppConfig.h")
 
 endfunction()
 
@@ -914,7 +916,9 @@ function(__generate_JuceHeader_header project_id)
     string(APPEND modules_includes "#include <${module_name}/${module_name}.h>\n")
   endforeach()
 
-  configure_file("${templates_DIR}/JuceHeader.h" "JuceLibraryCode/JuceHeader.h")
+  configure_file("${Reprojucer_templates_DIR}/JuceHeader.h"
+    "JuceLibraryCode/JuceHeader.h"
+  )
 
 endfunction()
 
@@ -963,13 +967,15 @@ function(__generate_plist_file target_name plist_suffix package_type bundle_sign
 
   set(plist_filename "Info-${plist_suffix}.plist")
   if(CMAKE_GENERATOR STREQUAL "Xcode")
-    configure_file("${templates_DIR}/Info-Xcode.plist" "${plist_filename}" @ONLY)
+    configure_file("${Reprojucer_templates_DIR}/Info-Xcode.plist"
+      "${plist_filename}" @ONLY
+    )
     set_target_properties(${target_name} PROPERTIES
       XCODE_ATTRIBUTE_INFOPLIST_FILE "${CMAKE_CURRENT_BINARY_DIR}/${plist_filename}"
       XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${JUCER_BUNDLE_IDENTIFIER}"
     )
   else()
-    configure_file("${templates_DIR}/Info.plist" "${plist_filename}" @ONLY)
+    configure_file("${Reprojucer_templates_DIR}/Info.plist" "${plist_filename}" @ONLY)
     set_target_properties(${target_name} PROPERTIES
       MACOSX_BUNDLE_BUNDLE_NAME "${JUCER_PROJECT_NAME}"
       MACOSX_BUNDLE_GUI_IDENTIFIER "${JUCER_BUNDLE_IDENTIFIER}"

--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -471,6 +471,14 @@ endfunction()
 
 function(jucer_project_end)
 
+  foreach(exporter ${Reprojucer_supported_exporters})
+    list(FIND Reprojucer_supported_exporters "${exporter}" exporter_index)
+    list(GET Reprojucer_supported_exporters_conditions ${exporter_index} condition)
+    if(${condition} AND NOT "${exporter}" IN_LIST JUCER_EXPORT_TARGETS)
+      message(WARNING "You might want to call jucer_export_target(\"${exporter}\").")
+    endif()
+  endforeach()
+
   if(DEFINED JUCER_PROJECT_CONFIGURATIONS)
     set(CMAKE_CONFIGURATION_TYPES ${JUCER_PROJECT_CONFIGURATIONS} PARENT_SCOPE)
   endif()

--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -21,6 +21,12 @@ cmake_minimum_required(VERSION 3.4)
 set(Reprojucer.cmake_DIR "${CMAKE_CURRENT_LIST_DIR}")
 set(Reprojucer_templates_DIR "${Reprojucer.cmake_DIR}/templates")
 
+set(Reprojucer_supported_exporters
+  "Xcode (MacOSX)"
+  "Visual Studio 2015"
+  "Visual Studio 2013"
+)
+
 
 function(jucer_project_begin)
 
@@ -334,15 +340,9 @@ endfunction()
 
 function(jucer_export_target exporter)
 
-  set(supported_exporters
-    "Xcode (MacOSX)"
-    "Visual Studio 2015"
-    "Visual Studio 2013"
-  )
-
-  if(NOT "${exporter}" IN_LIST supported_exporters)
+  if(NOT "${exporter}" IN_LIST Reprojucer_supported_exporters)
     message(FATAL_ERROR "Unsupported exporter: ${exporter}\n"
-      "Supported exporters: ${supported_exporters}"
+      "Supported exporters: ${Reprojucer_supported_exporters}"
     )
   endif()
   list(APPEND JUCER_EXPORT_TARGETS "${exporter}")
@@ -399,6 +399,12 @@ endfunction()
 
 
 function(jucer_export_target_configuration exporter NAME_TAG configuration_name)
+
+  if(NOT "${exporter}" IN_LIST Reprojucer_supported_exporters)
+    message(FATAL_ERROR "Unsupported exporter: ${exporter}\n"
+      "Supported exporters: ${Reprojucer_supported_exporters}"
+    )
+  endif()
 
   if(NOT "${exporter}" IN_LIST JUCER_EXPORT_TARGETS)
     message(FATAL_ERROR "Call jucer_export_target(\"${exporter}\") before "

--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -407,8 +407,8 @@ function(jucer_export_target_configuration exporter NAME_TAG configuration_name)
   endif()
 
   if(NOT "${exporter}" IN_LIST JUCER_EXPORT_TARGETS)
-    message(FATAL_ERROR "Call jucer_export_target(\"${exporter}\") before "
-      "calling jucer_export_target_configuration(\"${exporter}\")"
+    message(FATAL_ERROR "You must call jucer_export_target(\"${exporter}\") before "
+      "calling jucer_export_target_configuration(\"${exporter}\")."
     )
   endif()
 

--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -26,6 +26,11 @@ set(Reprojucer_supported_exporters
   "Visual Studio 2015"
   "Visual Studio 2013"
 )
+set(Reprojucer_supported_exporters_conditions
+  "APPLE"
+  "MSVC_VERSION\;EQUAL\;1900"
+  "MSVC_VERSION\;EQUAL\;1800"
+)
 
 
 function(jucer_project_begin)
@@ -348,11 +353,9 @@ function(jucer_export_target exporter)
   list(APPEND JUCER_EXPORT_TARGETS "${exporter}")
   set(JUCER_EXPORT_TARGETS ${JUCER_EXPORT_TARGETS} PARENT_SCOPE)
 
-  if(exporter STREQUAL "Xcode (MacOSX)" AND NOT APPLE)
-    return()
-  elseif(exporter STREQUAL "Visual Studio 2015" AND NOT MSVC_VERSION EQUAL 1900)
-    return()
-  elseif(exporter STREQUAL "Visual Studio 2013" AND NOT MSVC_VERSION EQUAL 1800)
+  list(FIND Reprojucer_supported_exporters "${exporter}" exporter_index)
+  list(GET Reprojucer_supported_exporters_conditions ${exporter_index} condition)
+  if(NOT ${condition})
     return()
   endif()
 
@@ -412,11 +415,9 @@ function(jucer_export_target_configuration exporter NAME_TAG configuration_name)
     )
   endif()
 
-  if(exporter STREQUAL "Xcode (MacOSX)" AND NOT APPLE)
-    return()
-  elseif(exporter STREQUAL "Visual Studio 2015" AND NOT MSVC_VERSION EQUAL 1900)
-    return()
-  elseif(exporter STREQUAL "Visual Studio 2013" AND NOT MSVC_VERSION EQUAL 1800)
+  list(FIND Reprojucer_supported_exporters "${exporter}" exporter_index)
+  list(GET Reprojucer_supported_exporters_conditions ${exporter_index} condition)
+  if(NOT ${condition})
     return()
   endif()
 


### PR DESCRIPTION
Alternative to #117.

@MartyLake: the first four commits of this PR are identical to the first four commits of #117 (i.e. only the last commit is different). Please review both PRs and tell me which one you prefer, thanks!