### PR TITLE
Clear xcodeResourcePaths like all other *Paths containers

### DIFF
--- a/Jucer2CMake/main.cpp
+++ b/Jucer2CMake/main.cpp
@@ -374,6 +374,7 @@ int main(int argc, char* argv[])
           filePaths.clear();
           doNotCompileFilePaths.clear();
           resourcePaths.clear();
+          xcodeResourcePaths.clear();
 
           processGroup(fileOrGroup);
         }


### PR DESCRIPTION
This should have been done in #120.

@MartyLake: FYI