### PR TITLE
Adapt to updated Ubuntu Trusty images on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,7 @@ matrix:
         apt:
           packages:
             - libasound2-dev
+            - libgl1-mesa-dev
             - libxcursor-dev
             - libxinerama-dev
             - libxrandr-dev


### PR DESCRIPTION
Adapts to https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch.

@MartyLake: FYI